### PR TITLE
Evaluate a "or" value lazily.

### DIFF
--- a/lib/monadic/maybe.rb
+++ b/lib/monadic/maybe.rb
@@ -66,6 +66,11 @@ module Monadic
     def or(other)
       self
     end
+
+    # @return always self for Just
+    def or_lazy
+      self
+    end
   end
 
   # Represents a NullObject
@@ -87,6 +92,11 @@ module Monadic
       # @return an alternative value, the passed value is coerced into Maybe, thus Nothing.or(1) will be Just(1)
       def or(other)
         Maybe.unit(other)
+      end
+
+      # @return an alternative value lazily, the passed value is coerced into Maybe, thus Nothing.or(1) will be Just(1)
+      def or_lazy
+        Maybe.unit(yield)
       end
 
       # def respond_to?

--- a/spec/maybe_spec.rb
+++ b/spec/maybe_spec.rb
@@ -42,6 +42,9 @@ describe Monadic::Maybe do
       Maybe(1).or(2).should              == Just(1)
       Maybe(nil).or(nil).should          == Nothing
       Maybe(nil).something.or(Just('')).fetch.should == Just('')
+
+      Maybe(1).or_lazy { 2 }.should           == Just(1)
+      Maybe(nil).or_lazy { 2 }.should         == Just(2)
     end
 
     it 'works with method_missing !caution! with Monad.methods like #join' do

--- a/spec/nothing_spec.rb
+++ b/spec/nothing_spec.rb
@@ -53,5 +53,7 @@ require 'spec_helper'
       Nothing.something.or(1).should == Just(1)
       Nothing.something.or(Just(nil)).should == Just(nil)
       Nothing.or('').should == Just('')
+
+      Nothing.or_lazy { 1 }.should == Just(1)
     end
   end


### PR DESCRIPTION
Sometime we want to evaluate a value of "or"'s parameter. For example,
the value should be a newly created object, but if Nothing.or(...) is
called, we don't want to create the object.
Because the current implemented "or" method is not lazily evaluated, we
have to use "if-then" statement in such a case.
In scala, a parameter of the "orElse" method is evaluated lazily. This
commit contains a new method "or_lazy" which evaluate the value lazily.