### PR TITLE
method_missing was acting like coerce but with a bad return value

### DIFF
--- a/lib/monadic/maybe.rb
+++ b/lib/monadic/maybe.rb
@@ -116,6 +116,10 @@ module Monadic
       def ===(other)
         other == Nothing
       end
+
+      def coerce(other)
+        raise TypeError
+      end
     end
   end
 


### PR DESCRIPTION
Coerce requires a two array return. in jruby 9.0.1.0 if you do `BigDecimal.new(1) == Nothing` it raises an error complaining about the return of coerce from Nothing. Defining a coerce method to allow it to properly realize it is not coercable.