### PR TITLE
Fix logic in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ def validate(person)
     age = age_expr.to_i
     case
     when age <=  0; Failure('Age must be > 0')
-    when age > 130; Failure('Age must be < 130')
+    when age >= 130; Failure('Age must be < 130')
     else Success(age)
     end
   }


### PR DESCRIPTION
Handle age of exactly 130 in `validate` example; otherwise the message is inconsistent with the check.