### PR TITLE
Return nil if coercion is impossible to conform with new rails expectations

### DIFF
--- a/lib/monadic/maybe.rb
+++ b/lib/monadic/maybe.rb
@@ -118,7 +118,7 @@ module Monadic
       end
 
       def coerce(other)
-        raise TypeError
+        nil
       end
     end
   end


### PR DESCRIPTION
When running monadic locally we are getting a lot of deprecation warnings along the lines of:

```
warning: in the next release. Return nil in #coerce if the coercion is impossible.
```

This PR should remedy that.
